### PR TITLE
Peter/aqua faang samples json schema

### DIFF
--- a/json_schema/module/samples/faang_samples_specimen_teleost.metadata_rules.json
+++ b/json_schema/module/samples/faang_samples_specimen_teleost.metadata_rules.json
@@ -1,0 +1,393 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Ruleset for specimens from teleost fish",
+  "title": "FAANG sample metadata rules for Teleostei",
+  "name": "faang_samples_specimen_teleost.metadata_rules",
+  "$async": true,
+  "type": "object",
+  "required": [
+    "generations_from_wild",
+    "hatching",
+    "maturity_state",
+    "time_post_fertilisation",
+    "rearing_conditions",
+    "diet",
+    "food_restriction",
+    "pre-hatching_water_temperature_average",
+    "post-hatching_water_temperature_average",
+    "average_water_oxygen",
+    "average_water_salinity",
+    "photoperiod",
+    "standard_length",
+    "total_length",
+    "fork_length",
+    "sampling_weight",
+    "sampling_day_start_time",
+    "sampling_day_end_time",
+    "method_of_schedule_1_killing",
+    "anaesthetic_or_sedative_name"
+  ],
+  "properties": {
+    "describedBy": {
+      "const": "https://github.com/FAANG/faang-metadata/blob/master/docs/faang_sample_metadata.md"
+    },
+    "schema_version": {
+      "description": "The version number of the schema in major.minor.patch format.",
+      "type": "string",
+      "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+      "example": "4.6.1"
+    },
+    "generations_from_wild": {
+      "type": "object",
+      "name": "Generations from wild",
+      "description": "Generations from wild, put 0 if a wild caught fish",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "integer"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["generations from wild"]
+        },
+        "mandatory": {
+          "const": "recommended"
+        }
+      }
+    },
+    "hatching": {
+      "type": "object",
+      "name": "hatching",
+      "description": "Sampled organism is pre- or post-hatching",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "pre",
+            "post",
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "maturity_state": {
+      "type": "object",
+      "name": "Maturity state",
+      "description": "Maturity state, either Mature (PATO_0001701) or Immature (PATO_0001501)",
+      "required": ["text"],
+      "properties": {
+        "type": "string",
+          "graph_restriction": {
+          "ontologies": ["obo:pato"],
+          "classes": ["PATO_0001501", "PATO_0001701"],
+          "relations": ["rdfs:subClassOf"],
+          "direct": false,
+          "include_self": true
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "time_post_fertilisation": {
+      "type": "object",
+      "name": "Time post fertilisation",
+      "description": "The time passed since fertilisation.",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["hours", "days", "months", "years"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "rearing_conditions": {
+      "type": "object",
+      "name": "Rearing conditions",
+      "description": "Food composition of organism",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "Indoors",
+            "tanks",
+            "recirculated systems",
+            "cages"
+          ]
+        },
+        "mandatory": {
+          "const": "optional"
+        }
+      }
+    },    
+    "diet": {
+      "type": "object",
+      "name": "diet",
+      "description": "Food composition of organism",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string"
+        },
+        "mandatory": {
+          "const": "recommended"
+        }
+      }
+    },
+    "food_restriction": {
+      "type": "object",
+      "name": "Food restriction",
+      "description": "Hours since last feeding",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "integer"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["hours"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "pre-hatching_water_temperature_average": {
+      "type": "object",
+      "name": "Pre-hatching water temperature average",
+      "description": "The average measured water temperature recoded post-hatching in degrees Celsius",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["Degrees celsius"]
+        },
+        "mandatory": {
+          "const": "recommended"
+        }
+      }
+    },
+    "post-hatching_water_temperature_average": {
+      "type": "object",
+      "name": "Post-hatching water temperature average",
+      "description": "The average measured water temperature recoded post-hatching in degrees Celsius",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["Degrees celsius"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "average_water_oxygen": {
+      "type": "object",
+      "name": "Average water oxygen length",
+      "description": "The average water oxygen during sampling",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["percent"]
+        },
+        "mandatory": {
+          "const": "optional"
+        }
+      }
+    }, 
+    "average_water_salinity": {
+      "type": "object",
+      "name": "Average water salinity",
+      "description": "The average water salinity during sampling",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["parts per thousand"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "photoperiod": {
+      "type": "object",
+      "name": "Photoperiod",
+      "description": "The photoperiod cycle recorded as light to dark ratio, or as 'natural light",
+      "required": ["text"],
+      "properties": {
+        "value": {
+          "oneOf": [
+            {"type": "string",
+            "pattern": "^[0-24]L:[0-24]D$"},
+            {"const": "natural light"}
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },   
+    "standard_length": {
+      "type": "object",
+      "name": "Standard length",
+      "description": "Measured length from the tip of the snout to the posterior end of the last vertebra",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["millimeters","centimeters"]
+        },
+        "mandatory": {
+          "const": "recommended"
+        }
+      }
+    },
+    "total_length": {
+      "type": "object",
+      "name": "Total length",
+      "description": "Measured length from the tip of the snout to the furtherst reach of the caudal fin",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["millimeters","centimeters"]
+        },
+        "mandatory": {
+          "const": "recommended"
+        }
+      }
+    },
+    "fork_length": {
+      "type": "object",
+      "name": "Fork length",
+      "description": "Measured length from the tip of the snout to the end of the middle caudal fin rays",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["millimeters","centimeters"]
+        },
+        "mandatory": {
+          "const": "recommended"
+        }
+      }
+    },
+    "sampling_weight": {
+      "type": "object",
+      "name": "Sampling weight",
+      "description": "Weight of entire organism at point of sampling",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["grams","kilograms"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "sampling_day_start_time": {
+      "type": "object",
+      "name": "Sampling data start time",
+      "description": "The time of day (local time) that sampling started",
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "type": "string",
+          "pattern": "^([0-1][0-9]|[2][0-3]):([0-5][0-9])$"
+          }
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "sampling_day_end_time": {
+      "type": "object",
+      "name": "Sampling data end time",
+      "description": "The time of day (local time) that sampling ended",
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "type": "string",
+          "pattern": "^([0-1][0-9]|[2][0-3]):([0-5][0-9])$"
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "method_of_schedule_1_killing": {
+      "type": "object",
+      "name": "Method of schedule 1 killing",
+      "description": "The method used for schedule 1 killing of organism",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            TODO
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "anaesthetic_or_sedative_name": {
+      "type": "object",
+      "name": "Anaesthetic or sedative name",
+      "description": "Anaesthetic or sedative name used in sampling. To add more controlled terms contact FAANG DCC",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            TODO
+          ]
+        },
+        "mandatory": {
+          "const": "optional"
+        }
+      }
+    },
+  }
+}

--- a/json_schema/module/samples/faang_samples_specimen_teleost.metadata_rules.json
+++ b/json_schema/module/samples/faang_samples_specimen_teleost.metadata_rules.json
@@ -6,26 +6,18 @@
   "$async": true,
   "type": "object",
   "required": [
-    "generations_from_wild",
     "hatching",
     "maturity_state",
     "time_post_fertilisation",
-    "rearing_conditions",
-    "diet",
     "food_restriction",
     "pre-hatching_water_temperature_average",
     "post-hatching_water_temperature_average",
-    "average_water_oxygen",
     "average_water_salinity",
     "photoperiod",
-    "standard_length",
-    "total_length",
-    "fork_length",
     "sampling_weight",
     "sampling_day_start_time",
     "sampling_day_end_time",
     "method_of_schedule_1_killing",
-    "anaesthetic_or_sedative_name"
   ],
   "properties": {
     "describedBy": {
@@ -36,6 +28,25 @@
       "type": "string",
       "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
       "example": "4.6.1"
+    },
+    "origin": {
+      "type": "object",
+      "name": "Origin",
+      "description": "Organism origin",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "Domesticated Double-haploid",
+            "Domesticated Isogenic",
+            "Wild",
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
     },
     "generations_from_wild": {
       "type": "object",
@@ -51,7 +62,74 @@
           "enum": ["generations from wild"]
         },
         "mandatory": {
-          "const": "recommended"
+          "const": "optional"
+        }
+      }
+    },
+    "experimental_strain_ID": {
+      "type": "object",
+      "name": "experimental strain ID",
+      "description": "Experimental strain ID",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string"
+        },
+        "mandatory": {
+          "const": "optional"
+        }
+      }
+    },
+    "genetic_background": {
+      "type": "object",
+      "name": "genetic_background",
+      "description": "Genetic background diversity.",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string"
+        },
+        "mandatory": {
+          "const": "optional"
+        }
+      }
+    },
+    "reproductive_strategy": {
+      "type": "object",
+      "name": "Reproductive strategy",
+      "description": "Reproductive strategy.",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "gonochoric",
+            "simultaneous hermaphrodite",
+            "successive hermaphrodite"
+          ]
+        },
+        "mandatory": {
+          "const": "optional"
+        }
+      }
+    },
+    "gonad_type": {
+      "type": "object",
+      "name": "Gonad type",
+      "description": "Gonad type",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "testis",
+            "ovary",
+            "intersexual/transitional stage",
+            "ovotestis"
+          ]
+        },
+        "mandatory": {
+          "const": "optional"
         }
       }
     },
@@ -110,26 +188,42 @@
         }
       }
     },
-    "rearing_conditions": {
+    "water_rearing_conditions": {
       "type": "object",
-      "name": "Rearing conditions",
-      "description": "Food composition of organism",
+      "name": "Water Rearing conditions",
+      "description": "The water rearing conditions.",
       "required": ["text"],
       "properties": {
         "text": {
           "type": "string",
           "enum": [
-            "Indoors",
-            "tanks",
-            "recirculated systems",
-            "cages"
+            "Closed water system (recirculatory)",
+            "Open water system"
           ]
         },
         "mandatory": {
           "const": "optional"
         }
       }
-    },    
+    },
+    "Post-hatching_animal_density": {
+      "type": "object",
+      "name": "Post-hatching animal density ",
+      "description": "Post-hatching animal density .",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "integer"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["hours"]TODO
+        },
+        "mandatory": {
+          "const": TODO
+        }
+      }
+    },   
     "diet": {
       "type": "object",
       "name": "diet",
@@ -176,7 +270,7 @@
           "enum": ["Degrees celsius"]
         },
         "mandatory": {
-          "const": "recommended"
+          "const": "mandatory"
         }
       }
     },
@@ -201,7 +295,7 @@
     "average_water_oxygen": {
       "type": "object",
       "name": "Average water oxygen length",
-      "description": "The average water oxygen during sampling",
+      "description": "The average water oxygen over organisms entire lifetime. Measured either as mg/L or %.",
       "required": ["value", "units"],
       "properties": {
         "value": {
@@ -209,7 +303,7 @@
         },
         "units": {
           "type": "string",
-          "enum": ["percent"]
+          "enum": ["%","mg/L"]
         },
         "mandatory": {
           "const": "optional"
@@ -219,7 +313,7 @@
     "average_water_salinity": {
       "type": "object",
       "name": "Average water salinity",
-      "description": "The average water salinity during sampling",
+      "description": "The average water salinity over organisms entire lifetime.",
       "required": ["value", "units"],
       "properties": {
         "value": {
@@ -309,7 +403,7 @@
     "sampling_weight": {
       "type": "object",
       "name": "Sampling weight",
-      "description": "Weight of entire organism at point of sampling",
+      "description": "Weight of entire organism at point of sampling.",
       "required": ["value", "units"],
       "properties": {
         "value": {
@@ -364,7 +458,12 @@
         "text": {
           "type": "string",
           "enum": [
-            TODO
+            "Non-lethal anaesthetic and exsanguination",
+            "Non-lethal anaesthetic and severing spinal cord",
+            "Lethal anaesthetic and exsanguination",
+            "Lethal anaesthetic and severing spinal cord",
+            "Concussive blow and exsanguination",
+            "Concussive blow and severing spinal cord",
           ]
         },
         "mandatory": {
@@ -381,7 +480,10 @@
         "text": {
           "type": "string",
           "enum": [
-            TODO
+            "Tricaine methanesulfonate (MS-222)",
+            "Tert-butyl hydroperoxide (TBH)",
+            "Benzocaine",
+            "Clove oil"
           ]
         },
         "mandatory": {

--- a/json_schema/module/samples/faang_samples_specimen_teleost_embryo.metadata_legacy_rules.json
+++ b/json_schema/module/samples/faang_samples_specimen_teleost_embryo.metadata_legacy_rules.json
@@ -1,0 +1,270 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Ruleset for specimens from teleost fish embryos",
+  "title": "FAANG sample metadata rules for Teleostei embryos",
+  "name": "faang_samples_specimen_teleost_embryo.metadata_rules",
+  "$async": true,
+  "type": "object",
+  "required": [
+    "origin",
+    "reproductive_strategy",
+    "hathcing",
+    "time_post_fertilisation",
+    "pre-hatching_water_temperature_average",
+    "post-hatching_water_temperature_average",
+    "degree_days",
+    "growth_media",
+    "medium_replacement_frequency",
+    "percentage_total_somite_number",
+    "average_water_salinity",
+    "photoperiod"
+  ],
+  "properties": {
+    "describedBy": {
+      "const": "https://github.com/FAANG/faang-metadata/blob/master/docs/faang_sample_metadata.md"
+    },
+    "schema_version": {
+      "description": "The version number of the schema in major.minor.patch format.",
+      "type": "string",
+      "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+      "example": "4.6.1"
+    },
+    "origin": {
+      "type": "object",
+      "name": "Origin",
+      "description": "Organism origin, one of four accepted terms.",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "Domesticated diploid",
+            "Domesticated Double-haploid",
+            "Domesticated Isogenic",
+            "Wild",
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "reproductive_strategy": {
+      "type": "object",
+      "name": "Reproductive strategy",
+      "description": "Reproductive strategy.",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "gonochoric",
+            "simultaneous hermaphrodite",
+            "successive hermaphrodite"
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "hatching": {
+      "type": "object",
+      "name": "hatching",
+      "description": "Sampled organism is pre- or post-hatching",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "pre",
+            "post",
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "time_post_fertilisation": {
+      "type": "object",
+      "name": "Time post fertilisation",
+      "description": "The time passed since fertilisation.",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["hours", "days", "months", "years"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "pre-hatching_water_temperature_average": {
+      "type": "object",
+      "name": "Pre-hatching water temperature average",
+      "description": "The average measured water temperature recoded post-hatching in degrees Celsius",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["Degrees celsius"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "post-hatching_water_temperature_average": {
+      "type": "object",
+      "name": "Post-hatching water temperature average",
+      "description": "The average measured water temperature recoded post-hatching in degrees Celsius",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["Degrees celsius"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "degree_days": {
+      "type": "object",
+      "name": "Degree days",
+      "description": "Degree days as calculated using this formula https://cdnsciencepub.com/doi/10.1139/cjfas-2013-0295",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "integer"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["Thermal time"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "growth_media": {
+      "type": "object",
+      "name": "Growing medium or water",
+      "description": "Whether Growing medium or water was used.",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "Water",
+            "Growing medium"
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "medium_replacement_frequency": {
+      "type": "object",
+      "name": "Frequency of medium replacement in days.",
+      "description": "Frequency of medium replacement in days.",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "integer"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["Days"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "percentage_total_somite_number": {
+      "type": "object",
+      "name": "Percentage of total somite number.",
+      "description": "Percentage of total somite number. Should have recorded 'Segmentation stage' for the 'developmental stage' under the Specimen rules.",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["%"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "average_water_salinity": {
+      "type": "object",
+      "name": "Average water salinity",
+      "description": "The average water salinity over organisms entire lifetime.",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["parts per thousand"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "photoperiod": {
+      "type": "object",
+      "name": "Photoperiod",
+      "description": "The photoperiod cycle recorded as light to dark ratio, or as 'natural light",
+      "required": ["text"],
+      "properties": {
+        "value": {
+          "oneOf": [
+            {"type": "string",
+            "pattern": "^[0-24]L:[0-24]D$"},
+            {"const": "natural light"}
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "generations_from_wild": {
+      "type": "object",
+      "name": "Generations from wild",
+      "description": "Generations from wild, put 0 if a wild caught fish",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "integer"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["generations from wild"]
+        },
+        "mandatory": {
+          "const": "recommended"
+        }
+      }
+    } 
+  }
+}

--- a/json_schema/module/samples/faang_samples_specimen_teleost_embryo.metadata_rules.json
+++ b/json_schema/module/samples/faang_samples_specimen_teleost_embryo.metadata_rules.json
@@ -6,13 +6,18 @@
   "$async": true,
   "type": "object",
   "required": [
+    "origin",
+    "reproductive_strategy",
     "hathcing",
     "time_post_fertilisation",
     "pre-hatching_water_temperature_average",
+    "post-hatching_water_temperature_average",
     "degree_days",
     "growth_media",
     "medium_replacement_frequency",
-
+    "percentage_total_somite_number",
+    "average_water_salinity",
+    "photoperiod"
   ],
   "properties": {
     "describedBy": {
@@ -23,6 +28,45 @@
       "type": "string",
       "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
       "example": "4.6.1"
+    },
+    "origin": {
+      "type": "object",
+      "name": "Origin",
+      "description": "Organism origin, one of four accepted terms.",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "Domesticated diploid",
+            "Domesticated Double-haploid",
+            "Domesticated Isogenic",
+            "Wild",
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "reproductive_strategy": {
+      "type": "object",
+      "name": "Reproductive strategy",
+      "description": "Reproductive strategy.",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "gonochoric",
+            "simultaneous hermaphrodite",
+            "successive hermaphrodite"
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
     },
     "hatching": {
       "type": "object",
@@ -63,6 +107,24 @@
     "pre-hatching_water_temperature_average": {
       "type": "object",
       "name": "Pre-hatching water temperature average",
+      "description": "The average measured water temperature recoded post-hatching in degrees Celsius",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["Degrees celsius"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "post-hatching_water_temperature_average": {
+      "type": "object",
+      "name": "Post-hatching water temperature average",
       "description": "The average measured water temperature recoded post-hatching in degrees Celsius",
       "required": ["value", "units"],
       "properties": {
@@ -149,6 +211,60 @@
           "const": "mandatory"
         }
       }
-    }
+    },
+    "average_water_salinity": {
+      "type": "object",
+      "name": "Average water salinity",
+      "description": "The average water salinity over organisms entire lifetime.",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["parts per thousand"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "photoperiod": {
+      "type": "object",
+      "name": "Photoperiod",
+      "description": "The photoperiod cycle recorded as light to dark ratio, or as 'natural light",
+      "required": ["text"],
+      "properties": {
+        "value": {
+          "oneOf": [
+            {"type": "string",
+            "pattern": "^[0-24]L:[0-24]D$"},
+            {"const": "natural light"}
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "generations_from_wild": {
+      "type": "object",
+      "name": "Generations from wild",
+      "description": "Generations from wild, put 0 if a wild caught fish",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "integer"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["generations from wild"]
+        },
+        "mandatory": {
+          "const": "recommended"
+        }
+      }
+    } 
   }
 }

--- a/json_schema/module/samples/faang_samples_specimen_teleost_embryo.metadata_rules.json
+++ b/json_schema/module/samples/faang_samples_specimen_teleost_embryo.metadata_rules.json
@@ -9,7 +9,9 @@
     "hathcing",
     "time_post_fertilisation",
     "pre-hatching_water_temperature_average",
-    "degree days"
+    "degree_days",
+    "Growing_media"
+
   ],
   "properties": {
     "describedBy": {
@@ -71,7 +73,7 @@
           "enum": ["Degrees celsius"]
         },
         "mandatory": {
-          "const": "recommended"
+          "const": "mandatory"
         }
       }
     },
@@ -86,12 +88,47 @@
         },
         "units": {
           "type": "string",
+          "enum": ["Thermal time"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "Growing_media": {
+      "type": "object",
+      "name": "Growing media or water",
+      "description": "Type of growing Media or water. Please contact FAANG DCC to add more controlled terms.",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "Water"
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "medium_replacement_frequency": {
+      "type": "object",
+      "name": "Frequency of medium replacement in days.",
+      "description": "Degree days",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "integer"
+        },
+        "units": {
+          "type": "string",
           "enum": ["Days"]
         },
         "mandatory": {
           "const": "mandatory"
         }
       }
-    }
+    },
   }
 }

--- a/json_schema/module/samples/faang_samples_specimen_teleost_embryo.metadata_rules.json
+++ b/json_schema/module/samples/faang_samples_specimen_teleost_embryo.metadata_rules.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Ruleset for specimens from teleost fish embryos",
+  "title": "FAANG sample metadata rules for Teleostei",
+  "name": "faang_samples_specimen_teleost_embryo.metadata_rules",
+  "$async": true,
+  "type": "object",
+  "required": [
+    "hathcing",
+    "time_post_fertilisation",
+    "pre-hatching_water_temperature_average",
+    "degree days"
+  ],
+  "properties": {
+    "describedBy": {
+      "const": "https://github.com/FAANG/faang-metadata/blob/master/docs/faang_sample_metadata.md"
+    },
+    "schema_version": {
+      "description": "The version number of the schema in major.minor.patch format.",
+      "type": "string",
+      "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+      "example": "4.6.1"
+    },
+    "hatching": {
+      "type": "object",
+      "name": "hatching",
+      "description": "Sampled organism is pre- or post-hatching",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "pre",
+            "post",
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "time_post_fertilisation": {
+      "type": "object",
+      "name": "Time post fertilisation",
+      "description": "The time passed since fertilisation.",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["hours", "days", "months", "years"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "pre-hatching_water_temperature_average": {
+      "type": "object",
+      "name": "Pre-hatching water temperature average",
+      "description": "The average measured water temperature recoded post-hatching in degrees Celsius",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["Degrees celsius"]
+        },
+        "mandatory": {
+          "const": "recommended"
+        }
+      }
+    },
+    "degree_days": {
+      "type": "object",
+      "name": "Degree days",
+      "description": "Degree days",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "integer"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["Days"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    }
+  }
+}

--- a/json_schema/module/samples/faang_samples_specimen_teleost_embryo.metadata_rules.json
+++ b/json_schema/module/samples/faang_samples_specimen_teleost_embryo.metadata_rules.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "Ruleset for specimens from teleost fish embryos",
-  "title": "FAANG sample metadata rules for Teleostei",
+  "title": "FAANG sample metadata rules for Teleostei embryos",
   "name": "faang_samples_specimen_teleost_embryo.metadata_rules",
   "$async": true,
   "type": "object",
@@ -10,7 +10,8 @@
     "time_post_fertilisation",
     "pre-hatching_water_temperature_average",
     "degree_days",
-    "Growing_media"
+    "growth_media",
+    "medium_replacement_frequency",
 
   ],
   "properties": {
@@ -80,7 +81,7 @@
     "degree_days": {
       "type": "object",
       "name": "Degree days",
-      "description": "Degree days",
+      "description": "Degree days as calculated using this formula https://cdnsciencepub.com/doi/10.1139/cjfas-2013-0295",
       "required": ["value", "units"],
       "properties": {
         "value": {
@@ -95,16 +96,17 @@
         }
       }
     },
-    "Growing_media": {
+    "growth_media": {
       "type": "object",
-      "name": "Growing media or water",
-      "description": "Type of growing Media or water. Please contact FAANG DCC to add more controlled terms.",
+      "name": "Growing medium or water",
+      "description": "Whether Growing medium or water was used.",
       "required": ["text"],
       "properties": {
         "text": {
           "type": "string",
           "enum": [
-            "Water"
+            "Water",
+            "Growing medium"
           ]
         },
         "mandatory": {
@@ -115,7 +117,7 @@
     "medium_replacement_frequency": {
       "type": "object",
       "name": "Frequency of medium replacement in days.",
-      "description": "Degree days",
+      "description": "Frequency of medium replacement in days.",
       "required": ["value", "units"],
       "properties": {
         "value": {
@@ -130,5 +132,23 @@
         }
       }
     },
+    "percentage_total_somite_number": {
+      "type": "object",
+      "name": "Percentage of total somite number.",
+      "description": "Percentage of total somite number. Should have recorded 'Segmentation stage' for the 'developmental stage' under the Specimen rules.",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["%"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    }
   }
 }

--- a/json_schema/module/samples/faang_samples_specimen_teleost_post-hatching.metadata_legacy_rules.json
+++ b/json_schema/module/samples/faang_samples_specimen_teleost_post-hatching.metadata_legacy_rules.json
@@ -1,0 +1,479 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Ruleset for post-hatching specimens from teleost fish",
+  "title": "FAANG sample metadata rules for post-hatching Teleostei",
+  "name": "faang_samples_specimen_teleost_post-hatching.metadata_rules",
+  "$async": true,
+  "type": "object",
+  "required": [
+    "origin",
+    "reproductive_strategy",
+    "gonad_type",
+    "hatching",
+    "maturity_state",
+    "time_post_fertilisation",
+    "post-hatching_animal_density",
+    "food_restriction",
+    "post-hatching_water_temperature_average",
+    "average_water_salinity",
+    "photoperiod",
+    "sampling_weight",
+    "method_of_schedule_1_killing",
+  ],
+  "properties": {
+    "describedBy": {
+      "const": "https://github.com/FAANG/faang-metadata/blob/master/docs/faang_sample_metadata.md"
+    },
+    "schema_version": {
+      "description": "The version number of the schema in major.minor.patch format.",
+      "type": "string",
+      "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+      "example": "4.6.1"
+    },
+    "origin": {
+      "type": "object",
+      "name": "Origin",
+      "description": "Organism origin, one of four accepted terms.",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "Domesticated diploid",
+            "Domesticated Double-haploid",
+            "Domesticated Isogenic",
+            "Wild",
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "reproductive_strategy": {
+      "type": "object",
+      "name": "Reproductive strategy",
+      "description": "Reproductive strategy.",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "gonochoric",
+            "simultaneous hermaphrodite",
+            "successive hermaphrodite"
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "gonad_type": {
+      "type": "object",
+      "name": "Gonad type",
+      "description": "Gonad type.",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "testis",
+            "ovary",
+            "intersexual/transitional stage",
+            "ovotestis",
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "generations_from_wild": {
+      "type": "object",
+      "name": "Generations from wild",
+      "description": "Generations from wild, put 0 if a wild caught fish",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "integer"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["generations from wild"]
+        },
+        "mandatory": {
+          "const": "recommended"
+        }
+      }
+    },
+    "experimental_strain_ID": {
+      "type": "object",
+      "name": "experimental strain ID",
+      "description": "Experimental strain ID",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string"
+        },
+        "mandatory": {
+          "const": "optional"
+        }
+      }
+    },
+    "genetic_background": {
+      "type": "object",
+      "name": "genetic_background",
+      "description": "Genetic background diversity.",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string"
+        },
+        "mandatory": {
+          "const": "optional"
+        }
+      }
+    },
+    "hatching": {
+      "type": "object",
+      "name": "hatching",
+      "description": "Sampled organism is pre- or post-hatching",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "pre",
+            "post",
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "maturity_state": {
+      "type": "object",
+      "name": "Maturity state",
+      "description": "Maturity state, either Mature (PATO_0001701) or Immature (PATO_0001501). Gonnad development state supported by micrographs.",
+      "required": ["text"],
+      "properties": {
+        "type": "string",
+          "graph_restriction": {
+          "ontologies": ["obo:pato"],
+          "classes": ["PATO_0001501", "PATO_0001701"],
+          "relations": ["rdfs:subClassOf"],
+          "direct": false,
+          "include_self": true
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "time_post_fertilisation": {
+      "type": "object",
+      "name": "Time post fertilisation",
+      "description": "The time passed since fertilisation.",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["hours", "days", "months", "years"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "water_rearing_conditions": {
+      "type": "object",
+      "name": "Water Rearing conditions",
+      "description": "The water rearing conditions.",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "Closed water system (recirculatory)",
+            "Open water system"
+          ]
+        },
+        "mandatory": {
+          "const": "optional"
+        }
+      }
+    },
+    "post-hatching_animal_density": {
+      "type": "object",
+      "name": "Post-hatching animal density ",
+      "description": "Post-hatching animal density measured in Kg/L.",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["Kg/L"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },   
+    "diet": {
+      "type": "object",
+      "name": "diet",
+      "description": "Food composition of organism",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string"
+        },
+        "mandatory": {
+          "const": "recommended"
+        }
+      }
+    },
+    "food_restriction": {
+      "type": "object",
+      "name": "Food restriction",
+      "description": "Hours since last feeding",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "integer"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["hours"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "post-hatching_water_temperature_average": {
+      "type": "object",
+      "name": "Post-hatching water temperature average",
+      "description": "The average measured water temperature recoded post-hatching in degrees Celsius",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["Degrees celsius"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "average_water_oxygen": {
+      "type": "object",
+      "name": "Average water oxygen",
+      "description": "The average water oxygen over organisms entire lifetime. Measured either as mg/L or %.",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["%","mg/L"]
+        },
+        "mandatory": {
+          "const": "optional"
+        }
+      }
+    }, 
+    "average_water_salinity": {
+      "type": "object",
+      "name": "Average water salinity",
+      "description": "The average water salinity over organisms entire lifetime.",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["parts per thousand"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "photoperiod": {
+      "type": "object",
+      "name": "Photoperiod",
+      "description": "The photoperiod cycle recorded as light to dark ratio, or as 'natural light",
+      "required": ["text"],
+      "properties": {
+        "value": {
+          "oneOf": [
+            {"type": "string",
+            "pattern": "^[0-24]L:[0-24]D$"},
+            {"const": "natural light"}
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },   
+    "standard_length": {
+      "type": "object",
+      "name": "Standard length",
+      "description": "Measured length from the tip of the snout to the posterior end of the last vertebra",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["millimeters","centimeters"]
+        },
+        "mandatory": {
+          "const": "recommended"
+        }
+      }
+    },
+    "total_length": {
+      "type": "object",
+      "name": "Total length",
+      "description": "Measured length from the tip of the snout to the furtherst reach of the caudal fin",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["millimeters","centimeters"]
+        },
+        "mandatory": {
+          "const": "recommended"
+        }
+      }
+    },
+    "fork_length": {
+      "type": "object",
+      "name": "Fork length",
+      "description": "Measured length from the tip of the snout to the end of the middle caudal fin rays",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["millimeters","centimeters"]
+        },
+        "mandatory": {
+          "const": "recommended"
+        }
+      }
+    },
+    "sampling_weight": {
+      "type": "object",
+      "name": "Sampling weight",
+      "description": "Weight of entire organism at point of sampling.",
+      "required": ["value", "units"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "units": {
+          "type": "string",
+          "enum": ["grams","kilograms"]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "sampling_day_start_time": {
+      "type": "object",
+      "name": "Sampling data start time",
+      "description": "The time of day (local time) that sampling started",
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "type": "string",
+          "pattern": "^([0-1][0-9]|[2][0-3]):([0-5][0-9])$"
+          }
+        },
+        "mandatory": {
+          "const": "recommended"
+        }
+      }
+    },
+    "sampling_day_end_time": {
+      "type": "object",
+      "name": "Sampling data end time",
+      "description": "The time of day (local time) that sampling ended",
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "type": "string",
+          "pattern": "^([0-1][0-9]|[2][0-3]):([0-5][0-9])$"
+        },
+        "mandatory": {
+          "const": "recommended"
+        }
+      }
+    },
+    "method_of_schedule_1_killing": {
+      "type": "object",
+      "name": "Method of schedule 1 killing",
+      "description": "The method used for schedule 1 killing of organism",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "Non-lethal anaesthetic and exsanguination",
+            "Non-lethal anaesthetic and severing spinal cord",
+            "Lethal anaesthetic and exsanguination",
+            "Lethal anaesthetic and severing spinal cord",
+            "Concussive blow and exsanguination",
+            "Concussive blow and severing spinal cord",
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "anaesthetic_or_sedative_name": {
+      "type": "object",
+      "name": "Anaesthetic or sedative name",
+      "description": "Anaesthetic or sedative name used in sampling. To add more controlled terms contact FAANG DCC",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "Tricaine methanesulfonate (MS-222)",
+            "Tert-butyl hydroperoxide (TBH)",
+            "Benzocaine",
+            "Clove oil"
+          ]
+        },
+        "mandatory": {
+          "const": "optional"
+        }
+      }
+    }
+  }
+}

--- a/json_schema/module/samples/faang_samples_specimen_teleost_post-hatching.metadata_rules.json
+++ b/json_schema/module/samples/faang_samples_specimen_teleost_post-hatching.metadata_rules.json
@@ -1,14 +1,18 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "description": "Ruleset for specimens from teleost fish",
-  "title": "FAANG sample metadata rules for Teleostei",
-  "name": "faang_samples_specimen_teleost.metadata_rules",
+  "description": "Ruleset for post-hatching specimens from teleost fish",
+  "title": "FAANG sample metadata rules for post-hatching Teleostei",
+  "name": "faang_samples_specimen_teleost_post-hatching.metadata_rules",
   "$async": true,
   "type": "object",
   "required": [
+    "origin",
+    "reproductive_strategy",
+    "gonad_type",
     "hatching",
     "maturity_state",
     "time_post_fertilisation",
+    "post-hatching_animal_density",
     "food_restriction",
     "pre-hatching_water_temperature_average",
     "post-hatching_water_temperature_average",
@@ -32,15 +36,55 @@
     "origin": {
       "type": "object",
       "name": "Origin",
-      "description": "Organism origin",
+      "description": "Organism origin, one of four accepted terms.",
       "required": ["text"],
       "properties": {
         "text": {
           "type": "string",
           "enum": [
+            "Domesticated diploid",
             "Domesticated Double-haploid",
             "Domesticated Isogenic",
             "Wild",
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "reproductive_strategy": {
+      "type": "object",
+      "name": "Reproductive strategy",
+      "description": "Reproductive strategy.",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "gonochoric",
+            "simultaneous hermaphrodite",
+            "successive hermaphrodite"
+          ]
+        },
+        "mandatory": {
+          "const": "mandatory"
+        }
+      }
+    },
+    "gonad_type": {
+      "type": "object",
+      "name": "Gonad type",
+      "description": "Gonad type.",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "enum": [
+            "testis",
+            "ovary",
+            "intersexual/transitional stage",
+            "ovotestis",
           ]
         },
         "mandatory": {
@@ -88,45 +132,6 @@
       "properties": {
         "text": {
           "type": "string"
-        },
-        "mandatory": {
-          "const": "optional"
-        }
-      }
-    },
-    "reproductive_strategy": {
-      "type": "object",
-      "name": "Reproductive strategy",
-      "description": "Reproductive strategy.",
-      "required": ["text"],
-      "properties": {
-        "text": {
-          "type": "string",
-          "enum": [
-            "gonochoric",
-            "simultaneous hermaphrodite",
-            "successive hermaphrodite"
-          ]
-        },
-        "mandatory": {
-          "const": "optional"
-        }
-      }
-    },
-    "gonad_type": {
-      "type": "object",
-      "name": "Gonad type",
-      "description": "Gonad type",
-      "required": ["text"],
-      "properties": {
-        "text": {
-          "type": "string",
-          "enum": [
-            "testis",
-            "ovary",
-            "intersexual/transitional stage",
-            "ovotestis"
-          ]
         },
         "mandatory": {
           "const": "optional"
@@ -206,21 +211,21 @@
         }
       }
     },
-    "Post-hatching_animal_density": {
+    "post-hatching_animal_density": {
       "type": "object",
       "name": "Post-hatching animal density ",
-      "description": "Post-hatching animal density .",
+      "description": "Post-hatching animal density measured in Kg/L.",
       "required": ["value", "units"],
       "properties": {
         "value": {
-          "type": "integer"
+          "type": "number"
         },
         "units": {
           "type": "string",
-          "enum": ["hours"]TODO
+          "enum": ["Kg/L"]
         },
         "mandatory": {
-          "const": TODO
+          "const": "mandatory"
         }
       }
     },   
@@ -490,6 +495,6 @@
           "const": "optional"
         }
       }
-    },
+    }
   }
 }

--- a/json_schema/module/samples/faang_samples_specimen_teleost_post-hatching.metadata_rules.json
+++ b/json_schema/module/samples/faang_samples_specimen_teleost_post-hatching.metadata_rules.json
@@ -14,13 +14,10 @@
     "time_post_fertilisation",
     "post-hatching_animal_density",
     "food_restriction",
-    "pre-hatching_water_temperature_average",
     "post-hatching_water_temperature_average",
     "average_water_salinity",
     "photoperiod",
     "sampling_weight",
-    "sampling_day_start_time",
-    "sampling_day_end_time",
     "method_of_schedule_1_killing",
   ],
   "properties": {
@@ -106,7 +103,7 @@
           "enum": ["generations from wild"]
         },
         "mandatory": {
-          "const": "optional"
+          "const": "recommended"
         }
       }
     },
@@ -159,7 +156,7 @@
     "maturity_state": {
       "type": "object",
       "name": "Maturity state",
-      "description": "Maturity state, either Mature (PATO_0001701) or Immature (PATO_0001501)",
+      "description": "Maturity state, either Mature (PATO_0001701) or Immature (PATO_0001501). Gonnad development state supported by micrographs.",
       "required": ["text"],
       "properties": {
         "type": "string",
@@ -261,24 +258,6 @@
         }
       }
     },
-    "pre-hatching_water_temperature_average": {
-      "type": "object",
-      "name": "Pre-hatching water temperature average",
-      "description": "The average measured water temperature recoded post-hatching in degrees Celsius",
-      "required": ["value", "units"],
-      "properties": {
-        "value": {
-          "type": "number"
-        },
-        "units": {
-          "type": "string",
-          "enum": ["Degrees celsius"]
-        },
-        "mandatory": {
-          "const": "mandatory"
-        }
-      }
-    },
     "post-hatching_water_temperature_average": {
       "type": "object",
       "name": "Post-hatching water temperature average",
@@ -299,7 +278,7 @@
     },
     "average_water_oxygen": {
       "type": "object",
-      "name": "Average water oxygen length",
+      "name": "Average water oxygen",
       "description": "The average water oxygen over organisms entire lifetime. Measured either as mg/L or %.",
       "required": ["value", "units"],
       "properties": {
@@ -435,7 +414,7 @@
           }
         },
         "mandatory": {
-          "const": "mandatory"
+          "const": "recommended"
         }
       }
     },
@@ -450,7 +429,7 @@
           "pattern": "^([0-1][0-9]|[2][0-3]):([0-5][0-9])$"
         },
         "mandatory": {
-          "const": "mandatory"
+          "const": "recommended"
         }
       }
     },


### PR DESCRIPTION
Requires comparable changes to validation tools and metadata templates to support new teleost metadata tabs. These tabs are required whenever organism is child of Teleostei NCBITaxon:32443. Validation should fail if they are not completed based on mandatory and recommended rules. 

embryo teleost rules apply when developmental stage is UBERON:0000068 or child of.
Otherwise the post hatching rules apply.

Also need to decide how to display these rules on https://data.faang.org/ruleset/samples